### PR TITLE
Balkans + game rule

### DIFF
--- a/common/decisions/ITA.txt
+++ b/common/decisions/ITA.txt
@@ -5855,6 +5855,7 @@ ITA_diplomacy_balkan_decision_category = {
 				NOT = { has_war_with = ROOT }
 				is_subject = no
 			}
+			date > 1937.5.1
 		}
 
 		visible = {

--- a/common/game_rules/00_st_game_rules.txt
+++ b/common/game_rules/00_st_game_rules.txt
@@ -52,8 +52,8 @@ use_new_tool = {
 		text = "No"
 		allow_achievements = no	
 	}
-	option = {
-		name = "YES"
-		text = "Yes"
-	}
+	#option = {
+	#	name = "YES"
+	#	text = "Yes"
+	#}
 }

--- a/common/national_focus/FA_hungary.txt
+++ b/common/national_focus/FA_hungary.txt
@@ -1598,13 +1598,7 @@ focus_tree = {
 					expire = 0
 				}
 			}
-			ROOT = {
-				create_wargoal = {
-					target = POL
-					type = take_claimed_state
-					expire = 0
-				}
-			}
+			add_state_claim = 88
 		}
 	}
 

--- a/events/DOD_Romania.txt
+++ b/events/DOD_Romania.txt
@@ -2329,7 +2329,7 @@ country_event = {
 			46 = {
 				add_resource = {
 					type = oil
-					amount = 16
+					amount = 26
 				}
 			}
 	}
@@ -2406,7 +2406,7 @@ country_event = {
 			add_tech_bonus = {
 				name = industry_tech_bonus
 				ahead_reduction = 1
-				bonus = 1
+				bonus = 0.5
 				uses = 2
 				category = industry
 			}

--- a/events/DOD_Romania.txt
+++ b/events/DOD_Romania.txt
@@ -2405,8 +2405,7 @@ country_event = {
 			}
 			add_tech_bonus = {
 				name = industry_tech_bonus
-				ahead_reduction = 1
-				bonus = 0.5
+				bonus = 1
 				uses = 2
 				category = industry
 			}


### PR DESCRIPTION
-Ape transfer tool option removed
-Hungarian poland war goal swapped to claims for faster justification instead
-Romania eco event bonus nerfed, oil option oil increased
-Italian yugo event set to similar time frame as war goal allowed to prevent early ai submitting to puppet and early formable.