### PR TITLE
TCDTF Vanilla Portugal Revamp

### DIFF
--- a/common/characters/POR.txt
+++ b/common/characters/POR.txt
@@ -1523,7 +1523,7 @@ characters = {
 				original_tag = POR
 			}
 			traits = {
-				army_regrouping_2
+				army_CombinedArms_3
 			}
 			cost = 100
 			ai_will_do = {

--- a/common/country_leader/00_traits.txt
+++ b/common/country_leader/00_traits.txt
@@ -6970,8 +6970,8 @@ leader_traits = {
 	liberal_journalist = {
 		sprite = 13
 		random = no
-		democratic_drift = 0.05
-		political_power_factor = 0.05
+		democratic_drift = 0.1
+		political_power_factor = 0.25
 
 		ai_will_do = {
 			factor = 2

--- a/common/country_leader/01_traits.txt
+++ b/common/country_leader/01_traits.txt
@@ -8362,8 +8362,8 @@ leader_traits = {
 	liberal_journalist = {
 		sprite = 13
 		random = no
-		democratic_drift = 0.05
-		political_power_factor = 0.05
+		democratic_drift = 0.1
+		political_power_factor = 0.25
 
 		ai_will_do = {
 			factor = 2

--- a/common/decisions/POR.txt
+++ b/common/decisions/POR.txt
@@ -1,0 +1,2923 @@
+POR_overseas_provinces = {
+
+	POR_angola_overseas_province = {
+
+		icon = infiltrate_state
+
+		available = {
+			
+			has_completed_focus = POR_luso_tropicalism
+			AND = {
+				POR = {
+					controls_state = 540
+					controls_state = 796
+					controls_state = 891
+					controls_state = 892
+				}
+				ANG = { exists = no }
+			}
+		}
+
+		cost = 0
+		fire_only_once = yes
+		days_remove = 730
+		ai_will_do = {
+			factor = 2
+		}
+		modifier = {
+			
+		}
+		visible = {
+			has_completed_focus = POR_luso_tropicalism
+		}
+		remove_effect = {
+			country_event = lar_portugal_overseas_provinces.1
+		}		
+	}
+
+	POR_mozambique_overseas_territory = {
+
+		icon = infiltrate_state
+
+		available = {
+			has_completed_focus = POR_luso_tropicalism
+			AND = {
+				POR = {
+					controls_state = 544
+					controls_state = 896
+					controls_state = 897
+				}
+				MZB = { exists = no }
+			}
+		}
+
+		cost = 0
+		fire_only_once = yes
+		days_remove = 730
+		ai_will_do = {
+			factor = 2
+		}
+
+		modifier = {
+			
+		}
+		
+		visible = {
+			has_completed_focus = POR_luso_tropicalism
+		}
+		remove_effect = {			
+			country_event = lar_portugal_overseas_provinces.2
+		}
+	}	
+}
+
+POR_arms_purchases = {
+
+	POR_buy_artillery_in_britain = { 
+
+		icon = generic_industry
+
+		available = {
+			ENG = {
+				has_opinion = {
+					target = ROOT
+					value > 0
+				}
+			}
+		}
+
+		cost = 0
+		days_remove = 90
+		days_re_enable = 90
+		ai_will_do = {
+			factor = 0.1
+			modifier = {
+				OR = {
+					num_of_civilian_factories < 5
+					stockpile_ratio = { 
+		  				archetype = artillery_equipment
+		  				ratio > 3
+		  			}
+				}
+				factor = 0
+			}
+			modifier = {
+				has_war = yes
+				factor = 10
+			}
+		}
+		modifier = {
+			civilian_factory_use = 1
+		}
+		visible = {
+			has_completed_focus = POR_british_guns
+			NOT = {
+				has_war_with = ENG
+			}
+			country_exists = ENG
+		}
+		complete_effect = {
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = 1
+				}
+				add_opinion_modifier = {
+					target = POR
+					modifier = POR_bought_guns
+				}
+
+			}
+			add_opinion_modifier = {
+				target = ENG
+				modifier = POR_sold_guns
+			}
+			add_opinion_modifier = {
+				target = ENG
+				modifier = POR_arms_trade
+			}
+		}
+		remove_effect = {
+			add_equipment_to_stockpile = {
+				type = artillery_equipment
+				amount = 100
+				producer = ENG
+			}
+			if = {
+				limit = {
+					has_dlc = "Arms Against Tyranny"
+				}
+				add_equipment_subsidy = {
+					cic = 250
+					equipment_type = artillery_equipment
+					seller_tags = { ENG } 
+				}
+			}
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+			}
+		}
+	}
+	POR_buy_aa_in_britain = { 
+
+		icon = generic_industry
+
+		available = {
+			ENG = {
+				has_opinion = {
+					target = ROOT
+					value > 0
+				}
+				has_tech = interwar_antiair
+			}
+		}
+
+		cost = 0
+		days_remove = 90
+		days_re_enable = 90
+		ai_will_do = {
+			factor = 0.1
+			modifier = {
+				OR = {
+					num_of_civilian_factories < 5
+					stockpile_ratio = { 
+		  				archetype = anti_air_equipment
+		  				ratio > 3
+		  			}
+				}
+				factor = 0
+			}
+			modifier = {
+				has_war = yes
+				factor = 10
+			}
+		}
+		modifier = {
+			civilian_factory_use = 1
+		}
+		visible = {
+			has_completed_focus = POR_british_guns
+			NOT = {
+				has_war_with = ENG
+			}
+			country_exists = ENG
+		}
+		complete_effect = {
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = 1
+				}
+				add_opinion_modifier = {
+					target = POR
+					modifier = POR_bought_guns
+				}
+			}
+			add_opinion_modifier = {
+				target = ENG
+				modifier = POR_sold_guns
+			}
+			add_opinion_modifier = {
+				target = ENG
+				modifier = POR_arms_trade
+			}
+		}
+		remove_effect = {
+			add_equipment_to_stockpile = {
+				type = anti_air_equipment
+				amount = 100
+				producer = ENG
+			}
+
+			if = {
+				limit = {
+					has_dlc = "Arms Against Tyranny"
+				}
+				add_equipment_subsidy = {
+					cic = 250
+					equipment_type = anti_air_equipment
+					seller_tags = { ENG } 
+				}
+			}
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+			}
+		}
+	}
+
+	POR_buy_at_in_britain = { 
+
+		icon = generic_industry
+
+		available = {
+			ENG = {
+				has_opinion = {
+					target = ROOT
+					value > 0
+				}
+				has_tech = interwar_antitank
+			}
+		}
+
+		cost = 0
+		days_remove = 90
+		days_re_enable = 90
+		ai_will_do = {
+			factor = 0.1
+			modifier = {
+				OR = {
+					num_of_civilian_factories < 5
+					stockpile_ratio = { 
+		  				archetype = anti_tank_equipment
+		  				ratio > 3
+		  			}
+				}
+				factor = 0
+			}
+			modifier = {
+				has_war = yes
+				factor = 10
+			}
+		}
+		modifier = {
+			civilian_factory_use = 1
+		}
+		visible = {
+			has_completed_focus = POR_british_guns
+			NOT = {
+				has_war_with = ENG
+			}
+			country_exists = ENG
+		}
+		complete_effect = {
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = 1
+				}
+				add_opinion_modifier = {
+					target = POR
+					modifier = POR_bought_guns
+				}
+			}
+			add_opinion_modifier = {
+				target = ENG
+				modifier = POR_sold_guns
+			}
+			add_opinion_modifier = {
+				target = ENG
+				modifier = POR_arms_trade
+			}
+		}
+		remove_effect = {
+			add_equipment_to_stockpile = {
+				type = anti_tank_equipment
+				amount = 100
+				producer = ENG
+			}
+			if = {
+				limit = {
+					has_dlc = "Arms Against Tyranny"
+				}
+				add_equipment_subsidy = {
+					cic = 250
+					equipment_type = anti_tank_equipment
+					seller_tags = { ENG } 
+				}
+			}
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+			}
+		}
+	}
+
+	POR_buy_ships_britain = {
+
+		icon = eng_trade_unions_support
+
+		available = {
+			ENG = {
+				has_war = no
+				has_opinion = {
+					target = ROOT
+					value > 0
+				}
+			}
+		}
+
+		cost = 0
+
+		ai_will_do = {
+			base = 10
+			modifier = {
+				factor = 5
+				ENG = { has_government = ROOT }
+				NOT = { has_government = fascism }
+			}
+			modifier = {
+				factor = 0
+				has_country_flag = POR_ships_purchase_timer
+			}
+			modifier = {
+				factor = 0
+				has_government = fascism
+				ENG = { 
+					NOT = { 
+						has_government = fascism 	 
+					}
+				}
+			}
+		}
+		
+		visible = {
+			has_completed_focus = POR_second_navy_reequipment
+			ENG = {
+				exists = yes
+				NOT = { has_war_with = ROOT }
+				has_civil_war = no
+				has_capitulated = no
+				owns_state = 126 #Owns London
+			}
+			NOT = {	has_country_flag = POR_ships_purchase_in_progress_flag }
+			NOT = { has_country_flag = POR_british_ships_purchase_rejected_flag }
+		}
+		complete_effect = {
+			ENG = {
+				country_event = { id = lar_portugal_purchase_ships.1 hours = 3 }
+			}
+			set_country_flag = POR_ships_purchase_in_progress_flag
+			set_country_flag = {
+  				flag = POR_ships_purchase_timer
+    			days = 180
+    			value = 1
+			}
+		}
+	}
+
+	POR_buy_ships_italy = {
+
+		icon = eng_trade_unions_support
+
+		available = {
+			ITA = {
+				has_war = no
+				has_opinion = {
+					target = ROOT
+					value > 0
+				}
+			}
+		}
+
+		cost = 0
+
+		ai_will_do = {
+			base = 10
+			modifier = {
+				factor = 5
+				ITA = { has_government = ROOT }
+			}
+			modifier = {
+				factor = 0
+				has_country_flag = POR_ships_purchase_timer
+			}
+		}
+		
+		visible = {
+			has_completed_focus = POR_second_navy_reequipment
+			ITA = {
+				exists = yes
+				NOT = { has_war_with = ROOT }
+				has_civil_war = no
+				has_capitulated = no
+				owns_state = 2 #Owns Rome
+			}
+			NOT = { has_country_flag = POR_ships_purchase_in_progress_flag }
+			NOT = { has_country_flag = POR_british_ships_purchase_rejected_flag }
+		}
+		complete_effect = {
+			ITA = {
+				country_event = { id = lar_portugal_purchase_ships.1 hours = 3}
+			}
+			set_country_flag = POR_ships_purchase_in_progress_flag
+			set_country_flag = {
+  				flag = POR_ships_purchase_timer
+    			days = 180
+    			value = 1
+			}
+		}
+	}
+
+	#Mission to track the progress of British SUBMARINES construction
+	POR_british_submarines_construction_progress = {
+		
+		icon = generic_naval
+
+		allowed = {
+			original_tag = POR
+		}
+
+		visible = {
+			has_country_flag = POR_purchase_british_submarines_flag
+		}
+
+		modifier = {
+			civilian_factory_use = 1
+		}
+
+		days_remove = 365
+
+		cancel_trigger = {
+			OR = {
+				NOT = { country_exists = POR }
+				NOT = { country_exists = ENG }
+				ENG = {
+					OR = {
+						has_war_with = ROOT
+						has_civil_war = yes
+						has_capitulated = yes
+						NOT = { owns_state = 126 } #Owns London
+					}
+				}
+			}
+		}
+
+		#On Activation
+		complete_effect ={
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = 1
+				}
+			}
+		}
+
+		#Fail
+		cancel_effect = {
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+				remove_opinion_modifier = {
+					target = POR
+					modifier = POR_bought_ships
+				}
+			}
+			remove_opinion_modifier = {
+				target = ENG
+				modifier = POR_sold_ships
+			}
+			remove_opinion_modifier = {
+				target = ENG
+				modifier = POR_ships_trade
+			}			
+			clr_country_flag = POR_purchase_british_submarines_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+
+		#Success
+		remove_effect = {
+			hidden_effect = { add_manpower = 600 }
+			if = {
+				limit = { has_dlc = "Man the Guns" }
+				if = { 
+					limit = {
+						ENG = { has_tech = advanced_ship_hull_submarine }
+					}
+					ENG = {
+						create_equipment_variant = {
+							name = "Delfim Class"				
+							type = ship_hull_submarine_4
+							name_group = POR_SS_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_torpedo_slot = ship_torpedo_sub_1
+								fixed_ship_engine_slot = sub_ship_engine_1
+								rear_1_custom_slot = ship_torpedo_sub_1
+								front_1_custom_slot = ship_torpedo_sub_1
+							}
+						}
+					}
+					create_ship = { type = ship_hull_submarine_4 equipment_variant = "Delfim Class" creator = ENG }
+					create_ship = { type = ship_hull_submarine_4 equipment_variant = "Delfim Class" creator = ENG }
+					create_ship = { type = ship_hull_submarine_4 equipment_variant = "Delfim Class" creator = ENG }
+				}
+				else_if = { 
+					limit = {
+						ENG = { has_tech = improved_ship_hull_submarine }
+					}
+					ENG = {
+						create_equipment_variant = {
+							name = "Delfim Class"				
+							type = ship_hull_submarine_3
+							name_group = POR_SS_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_torpedo_slot = ship_torpedo_sub_1
+								fixed_ship_engine_slot = sub_ship_engine_1
+								rear_1_custom_slot = ship_torpedo_sub_1
+							}
+						}
+					}
+					create_ship = { type = ship_hull_submarine_3 equipment_variant = "Delfim Class" creator = ENG }
+					create_ship = { type = ship_hull_submarine_3 equipment_variant = "Delfim Class" creator = ENG }
+					create_ship = { type = ship_hull_submarine_3 equipment_variant = "Delfim Class" creator = ENG }
+				}
+				else = {
+					create_ship = { type = ship_hull_submarine_2 equipment_variant = "Delfim Class" creator = POR }
+					create_ship = { type = ship_hull_submarine_2 equipment_variant = "Delfim Class" creator = POR }
+					create_ship = { type = ship_hull_submarine_2 equipment_variant = "Delfim Class" creator = POR }
+				}
+			}
+			else = { #NO MTG
+				if = { 
+					limit = {
+						ENG = { has_tech = advanced_submarine }
+					}
+					ENG = {
+						create_equipment_variant = {
+							name = "Delfim Class"
+							type = submarine_4
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 3
+								sub_torpedo_upgrade = 3
+								sub_stealth_upgrade = 3
+								sub_engine_upgrade = 2
+							}
+						}
+					}
+					create_ship = { type = submarine_4 equipment_variant = "Delfim Class" creator = ENG }
+					create_ship = { type = submarine_4 equipment_variant = "Delfim Class" creator = ENG }
+					create_ship = { type = submarine_4 equipment_variant = "Delfim Class" creator = ENG }
+				}
+				else_if = { 
+					limit = {
+						ENG = { has_tech = improved_submarine }
+					}
+					ENG = {
+						create_equipment_variant = {
+							name = "Delfim Class"
+							type = submarine_3
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 2
+								sub_torpedo_upgrade = 3
+								sub_stealth_upgrade = 2
+								sub_engine_upgrade = 2
+							}
+						}
+					}
+					create_ship = { type = submarine_3 equipment_variant = "Delfim Class" creator = ENG }
+					create_ship = { type = submarine_3 equipment_variant = "Delfim Class" creator = ENG }
+					create_ship = { type = submarine_3 equipment_variant = "Delfim Class" creator = ENG }
+				}
+				else_if = { 
+					limit = {
+						ENG = { has_tech = basic_submarine }
+					}
+					ENG = {
+						create_equipment_variant = {
+							name = "Delfim Class"
+							type = submarine_2
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 2
+								sub_torpedo_upgrade = 2
+								sub_stealth_upgrade = 2
+								sub_engine_upgrade = 1
+							}
+						}
+					}
+					create_ship = { type = submarine_2 equipment_variant = "Delfim Class" creator = ENG }
+					create_ship = { type = submarine_2 equipment_variant = "Delfim Class" creator = ENG }
+					create_ship = { type = submarine_2 equipment_variant = "Delfim Class" creator = ENG }
+				}
+				else = {
+					create_equipment_variant = {
+						name = "Delfim Class"
+						type = submarine_2
+						allow_without_tech = yes
+						upgrades = {
+							ship_reliability_upgrade = 2
+							sub_torpedo_upgrade = 2
+							sub_stealth_upgrade = 1
+							sub_engine_upgrade = 0
+						}
+					}
+					create_ship = { type = submarine_2 equipment_variant = "Delfim Class" creator = POR }
+					create_ship = { type = submarine_2 equipment_variant = "Delfim Class" creator = POR }
+					create_ship = { type = submarine_2 equipment_variant = "Delfim Class" creator = POR }
+				}
+			}
+
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+			}
+			country_event = lar_portugal_purchase_ships.4
+			set_country_flag = POR_ships_purchased_flag
+			clr_country_flag = POR_purchase_british_submarines_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+	}
+
+	#Mission to track the progress of Italian SUBMARINES construction
+	POR_italian_submarines_construction_progress = {
+		
+		icon = generic_naval
+
+		allowed = {
+			original_tag = POR
+		}
+
+		visible = {
+			has_country_flag = POR_purchase_italian_submarines_flag
+		}
+
+		modifier = {
+			civilian_factory_use = 1
+		}
+
+		days_remove = 365
+
+		cancel_trigger = {
+			OR = {
+				NOT = { country_exists = POR }
+				NOT = { country_exists = ITA }
+				ITA = {
+					OR = {
+						has_war_with = ROOT
+						has_civil_war = yes
+						has_capitulated = yes
+						NOT = { owns_state = 2 } #Owns Rome
+					}
+				}
+			}	
+		}
+
+
+		#On Activation
+		complete_effect = {
+			ITA = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = 1
+				}
+			}
+		}
+
+		#Fail
+		cancel_effect = {
+			ITA = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+				remove_opinion_modifier = {
+					target = POR
+					modifier = POR_bought_ships
+				}
+			}
+			remove_opinion_modifier = {
+				target = ITA
+				modifier = POR_sold_ships
+			}
+			remove_opinion_modifier = {
+				target = ITA
+				modifier = POR_ships_trade
+			}			
+			clr_country_flag = POR_purchase_italian_submarines_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+
+		#Success
+		remove_effect = {
+			hidden_effect = { add_manpower = 600 }
+			if = {
+				limit = { has_dlc = "Man the Guns" }
+				if = { 
+					limit = {
+						ITA = { has_tech = advanced_ship_hull_submarine }
+					}
+					ITA = {
+						create_equipment_variant = {
+							name = "Delfim Class"				
+							type = ship_hull_submarine_4
+							name_group = POR_SS_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_torpedo_slot = ship_torpedo_sub_1
+								fixed_ship_engine_slot = sub_ship_engine_1
+								rear_1_custom_slot = ship_torpedo_sub_1
+								front_1_custom_slot = ship_torpedo_sub_1
+							}
+						}
+					}
+					create_ship = { type = ship_hull_submarine_4 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = ship_hull_submarine_4 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = ship_hull_submarine_4 equipment_variant = "Delfim Class" creator = ITA }
+				}
+				else_if = { 
+					limit = {
+						ITA = { has_tech = improved_ship_hull_submarine }
+					}
+					ITA = {
+						create_equipment_variant = {
+							name = "Delfim Class"				
+							type = ship_hull_submarine_3
+							name_group = POR_SS_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_torpedo_slot = ship_torpedo_sub_1
+								fixed_ship_engine_slot = sub_ship_engine_1
+								rear_1_custom_slot = ship_torpedo_sub_1
+							}
+						}
+					}
+					create_ship = { type = ship_hull_submarine_3 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = ship_hull_submarine_3 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = ship_hull_submarine_3 equipment_variant = "Delfim Class" creator = ITA }
+				}
+				else = {
+					create_ship = { type = ship_hull_submarine_2 equipment_variant = "Delfim Class" creator = POR }
+					create_ship = { type = ship_hull_submarine_2 equipment_variant = "Delfim Class" creator = POR }
+					create_ship = { type = ship_hull_submarine_2 equipment_variant = "Delfim Class" creator = POR }
+				}
+			}
+			else = { #NO MTG
+				if = { 
+					limit = {
+						ITA = { has_tech = advanced_submarine }
+					}
+					ITA = {
+						create_equipment_variant = {
+							name = "Delfim Class"
+							type = submarine_4
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 3
+								sub_torpedo_upgrade = 3
+								sub_stealth_upgrade = 3
+								sub_engine_upgrade = 2
+							}
+						}
+					}
+					create_ship = { type = submarine_4 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = submarine_4 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = submarine_4 equipment_variant = "Delfim Class" creator = ITA }
+				}
+				else_if = { 
+					limit = {
+						ITA = { has_tech = improved_submarine }
+					}
+					ITA = {
+						create_equipment_variant = {
+							name = "Delfim Class"
+							type = submarine_3
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 2
+								sub_torpedo_upgrade = 3
+								sub_stealth_upgrade = 2
+								sub_engine_upgrade = 2
+							}
+						}
+					}
+					create_ship = { type = submarine_3 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = submarine_3 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = submarine_3 equipment_variant = "Delfim Class" creator = ITA }
+				}
+				else_if = { 
+					limit = {
+						ITA = { has_tech = basic_submarine }
+					}
+					ITA = {
+						create_equipment_variant = {
+							name = "Delfim Class"
+							type = submarine_2
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 2
+								sub_torpedo_upgrade = 2
+								sub_stealth_upgrade = 2
+								sub_engine_upgrade = 1
+							}
+						}
+					}
+					create_ship = { type = submarine_2 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = submarine_2 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = submarine_2 equipment_variant = "Delfim Class" creator = ITA }
+				}
+				else = {
+					ITA = {
+						create_equipment_variant = {
+							name = "Delfim Class"
+							type = submarine_1
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 2
+								sub_torpedo_upgrade = 2
+								sub_stealth_upgrade = 1
+								sub_engine_upgrade = 0
+							}
+						}
+					}
+					create_ship = { type = submarine_1 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = submarine_1 equipment_variant = "Delfim Class" creator = ITA }
+					create_ship = { type = submarine_1 equipment_variant = "Delfim Class" creator = ITA }
+				}
+			}
+
+			ITA = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+			}
+			country_event = lar_portugal_purchase_ships.4
+			set_country_flag = POR_ships_purchased_flag
+			clr_country_flag = POR_purchase_italian_submarines_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+	}
+
+	#Mission to track the progress of British DESTROYERS construction
+	POR_british_destroyers_construction_progress = {
+		
+		icon = generic_naval
+
+		allowed = {
+			original_tag = POR
+		}
+
+		visible = {
+			has_country_flag = POR_purchase_british_destroyers_flag
+		}
+		
+		modifier = {
+			civilian_factory_use = 1
+		}
+
+		days_remove = 365
+
+		cancel_trigger = {
+			OR = {
+				NOT = { country_exists = POR }
+				NOT = { country_exists = ENG }
+				ENG = {
+					OR = {
+						has_war_with = ROOT
+						has_civil_war = yes
+						has_capitulated = yes
+						NOT = { owns_state = 126 } #Owns London
+					}
+				}
+			}
+		}
+
+		#On Activation
+		complete_effect = {
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = 1
+				}
+			}
+		}
+
+		#Fail
+		cancel_effect = {
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+				remove_opinion_modifier = {
+					target = POR
+					modifier = POR_bought_ships
+				}
+			}
+			remove_opinion_modifier = {
+				target = ENG
+				modifier = POR_sold_ships
+			}
+			remove_opinion_modifier = {
+				target = ENG
+				modifier = POR_ships_trade
+			}		
+			clr_country_flag = POR_purchase_british_destroyers_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+
+		#Success
+		remove_effect = {
+			if = {
+				limit = { has_dlc = "Man the Guns" }
+				if = { 
+					limit = {
+						ENG = { has_tech = advanced_ship_hull_light }
+					}
+					hidden_effect = { add_manpower = 1000 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Vouga Class"	
+							type = ship_hull_light_4
+							name_group = POR_DD_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_battery_1
+								fixed_ship_anti_air_slot = ship_anti_air_1
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = light_ship_engine_2
+								fixed_ship_torpedo_slot = ship_torpedo_1
+								mid_1_custom_slot = ship_mine_layer_1
+								rear_1_custom_slot = ship_depth_charge_1
+							}
+						}
+					}
+					create_ship = { type = ship_hull_light_4 equipment_variant = "Vouga Class" creator = ENG }
+					create_ship = { type = ship_hull_light_4 equipment_variant = "Vouga Class" creator = ENG }
+				}
+				else_if = { 
+					limit = {
+						ENG = { has_tech = improved_ship_hull_light }
+					}
+					hidden_effect = { add_manpower = 800 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Vouga Class"	
+							type = ship_hull_light_3
+							name_group = POR_DD_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_battery_1
+								fixed_ship_anti_air_slot = ship_anti_air_1
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = light_ship_engine_2
+								fixed_ship_torpedo_slot = ship_torpedo_1
+								mid_1_custom_slot = ship_mine_layer_1
+								rear_1_custom_slot = ship_depth_charge_1
+							}
+						}
+					}
+					create_ship = { type = ship_hull_light_3 equipment_variant = "Vouga Class" creator = ENG }
+					create_ship = { type = ship_hull_light_3 equipment_variant = "Vouga Class" creator = ENG }
+				}
+				else = {
+					hidden_effect = { add_manpower = 650 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Vouga Class"	
+							type = ship_hull_light_2
+							name_group = POR_DD_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_battery_1
+								fixed_ship_anti_air_slot = ship_anti_air_1
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = light_ship_engine_2
+								fixed_ship_torpedo_slot = ship_torpedo_1
+								mid_1_custom_slot = ship_mine_layer_1
+								rear_1_custom_slot = ship_depth_charge_1
+							}
+						}
+					}
+					create_ship = { type = ship_hull_light_2 equipment_variant = "Vouga Class" creator = ENG }
+					create_ship = { type = ship_hull_light_2 equipment_variant = "Vouga Class" creator = ENG }
+				}
+			}
+			else = { #NO MTG
+				if = { 
+					limit = {
+						ENG = { has_tech = advanced_destroyer }
+					}
+					hidden_effect = { add_manpower = 500 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Vouga Class"
+							type = destroyer_4
+							allow_without_tech = yes
+							upgrades = {
+								ship_torpedo_upgrade = 4
+								destroyer_engine_upgrade = 2
+								ship_ASW_upgrade = 3
+								ship_anti_air_upgrade = 3
+							}
+						}
+					}
+					create_ship = { type = destroyer_4 equipment_variant = "Vouga Class" creator = ENG }
+					create_ship = { type = destroyer_4 equipment_variant = "Vouga Class" creator = ENG }
+				}
+				else_if = { 
+					limit = {
+						ENG = { has_tech = improved_destroyer }
+					}
+					hidden_effect = { add_manpower = 400 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Vouga Class"
+							type = destroyer_3
+							allow_without_tech = yes
+							upgrades = {
+								ship_torpedo_upgrade = 3
+								destroyer_engine_upgrade = 2
+								ship_ASW_upgrade = 2
+								ship_anti_air_upgrade = 3
+							}
+						}
+					}
+					create_ship = { type = destroyer_3 equipment_variant = "Vouga Class" creator = ENG }
+					create_ship = { type = destroyer_3 equipment_variant = "Vouga Class" creator = ENG }
+				}
+				else = {
+					hidden_effect = { add_manpower = 325 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Vouga Class"
+							type = destroyer_2
+							allow_without_tech = yes
+							upgrades = {
+								ship_torpedo_upgrade = 2
+								destroyer_engine_upgrade = 1
+								ship_ASW_upgrade = 2
+								ship_anti_air_upgrade = 3
+							}
+						}
+					}
+					create_ship = { type = destroyer_2 equipment_variant = "Vouga Class" creator = ENG }
+					create_ship = { type = destroyer_2 equipment_variant = "Vouga Class" creator = ENG }
+				}
+			}
+
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+			}
+			country_event = lar_portugal_purchase_ships.5
+			set_country_flag = POR_ships_purchased_flag
+			clr_country_flag = POR_purchase_british_destroyers_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+	}
+
+	#Mission to track the progress of Italian DESTROYERS construction
+	POR_italian_destroyers_construction_progress = {
+		
+		icon = generic_naval
+
+		allowed = {
+			original_tag = POR
+		}
+
+		visible = {
+			has_country_flag = POR_purchase_italian_destroyers_flag
+		}
+
+		modifier = {
+			civilian_factory_use = 1
+		}
+
+		days_remove = 365
+
+		cancel_trigger = {
+			OR = {
+				NOT = { country_exists = POR }
+				NOT = { country_exists = ITA }
+				ITA = {
+					OR = {
+						has_war_with = ROOT
+						has_civil_war = yes
+						has_capitulated = yes
+						NOT = { owns_state = 2 } #Owns Rome
+					}
+				}
+			}
+		}
+
+		#On Activation
+		complete_effect ={
+			ITA = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = 1
+				}
+			}
+		}
+
+		#Fail
+		cancel_effect = {
+			ITA = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+				remove_opinion_modifier = {
+					target = POR
+					modifier = POR_bought_ships
+				}
+			}
+			remove_opinion_modifier = {
+				target = ITA
+				modifier = POR_sold_ships
+			}
+			remove_opinion_modifier = {
+				target = ITA
+				modifier = POR_ships_trade
+			}		
+			clr_country_flag = POR_purchase_italian_destroyers_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+
+		is_good = yes
+		#Success
+		remove_effect = {
+			if = {
+				limit = { has_dlc = "Man the Guns" }
+				if = { 
+					limit = {
+						ITA = { has_tech = advanced_ship_hull_light }
+					}
+					hidden_effect = { add_manpower = 1000 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Vouga Class"	
+							type = ship_hull_light_4
+							name_group = POR_DD_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_battery_1
+								fixed_ship_anti_air_slot = ship_anti_air_1
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = light_ship_engine_2
+								fixed_ship_torpedo_slot = ship_torpedo_1
+								mid_1_custom_slot = ship_mine_layer_1
+								rear_1_custom_slot = ship_depth_charge_1
+							}
+						}
+					}
+					create_ship = { type = ship_hull_light_4 equipment_variant = "Vouga Class" creator = ITA }
+					create_ship = { type = ship_hull_light_4 equipment_variant = "Vouga Class" creator = ITA }
+				}
+				else_if = { 
+					limit = {
+						ITA = { has_tech = improved_ship_hull_light }
+					}
+					hidden_effect = { add_manpower = 800 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Vouga Class"	
+							type = ship_hull_light_3
+							name_group = POR_DD_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_battery_1
+								fixed_ship_anti_air_slot = ship_anti_air_1
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = light_ship_engine_2
+								fixed_ship_torpedo_slot = ship_torpedo_1
+								mid_1_custom_slot = ship_mine_layer_1
+								rear_1_custom_slot = ship_depth_charge_1
+							}
+						}
+					}
+					create_ship = { type = ship_hull_light_3 equipment_variant = "Vouga Class" creator = ITA }
+					create_ship = { type = ship_hull_light_3 equipment_variant = "Vouga Class" creator = ITA }
+				}
+				else = {
+					hidden_effect = { add_manpower = 650 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Vouga Class"	
+							type = ship_hull_light_2
+							name_group = POR_DD_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_battery_1
+								fixed_ship_anti_air_slot = ship_anti_air_1
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = light_ship_engine_2
+								fixed_ship_torpedo_slot = ship_torpedo_1
+								mid_1_custom_slot = ship_mine_layer_1
+								rear_1_custom_slot = ship_depth_charge_1
+							}
+						}
+					}
+					create_ship = { type = ship_hull_light_2 equipment_variant = "Vouga Class" creator = ITA }
+					create_ship = { type = ship_hull_light_2 equipment_variant = "Vouga Class" creator = ITA }
+				}
+			}
+			else = { #NO MTG
+				if = { 
+					limit = {
+						ITA = { has_tech = advanced_destroyer }
+					}
+					hidden_effect = { add_manpower = 500 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Vouga Class"
+							type = destroyer_4
+							allow_without_tech = yes
+							upgrades = {
+								ship_torpedo_upgrade = 4
+								destroyer_engine_upgrade = 2
+								ship_ASW_upgrade = 3
+								ship_anti_air_upgrade = 3
+							}
+						}
+					}
+					create_ship = { type = destroyer_4 equipment_variant = "Vouga Class" creator = ITA }
+					create_ship = { type = destroyer_4 equipment_variant = "Vouga Class" creator = ITA }
+				}
+				else_if = { 
+					limit = {
+						ITA = { has_tech = improved_destroyer }
+					}
+					hidden_effect = { add_manpower = 400 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Vouga Class"
+							type = destroyer_3
+							allow_without_tech = yes
+							upgrades = {
+								ship_torpedo_upgrade = 3
+								destroyer_engine_upgrade = 2
+								ship_ASW_upgrade = 2
+								ship_anti_air_upgrade = 3
+							}
+						}
+					}
+					create_ship = { type = destroyer_3 equipment_variant = "Vouga Class" creator = ITA }
+					create_ship = { type = destroyer_3 equipment_variant = "Vouga Class" creator = ITA }
+				}
+				else_if = {
+					limit = {
+						ITA = { has_tech = basic_destroyer }
+					}
+					hidden_effect = { add_manpower = 325 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Vouga Class"
+							type = destroyer_2
+							allow_without_tech = yes
+							upgrades = {
+								ship_torpedo_upgrade = 2
+								destroyer_engine_upgrade = 1
+								ship_ASW_upgrade = 2
+								ship_anti_air_upgrade = 3
+							}
+						}
+					}
+					create_ship = { type = destroyer_2 equipment_variant = "Vouga Class" creator = ITA }
+					create_ship = { type = destroyer_2 equipment_variant = "Vouga Class" creator = ITA }
+				}
+				else = {				
+					hidden_effect = { add_manpower = 250 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Vouga Class"
+							type = destroyer_1
+							allow_without_tech = yes
+							upgrades = {
+								ship_torpedo_upgrade = 1
+								destroyer_engine_upgrade = 1
+								ship_ASW_upgrade = 2
+								ship_anti_air_upgrade = 2
+							}
+						}
+					}
+					create_ship = { type = destroyer_1 equipment_variant = "Vouga Class" creator = ITA }
+					create_ship = { type = destroyer_1 equipment_variant = "Vouga Class" creator = ITA }
+				}
+			}
+
+			ITA = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+			}
+			country_event = lar_portugal_purchase_ships.5
+			set_country_flag = POR_ships_purchased_flag
+			clr_country_flag = POR_purchase_italian_destroyers_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+	}
+
+	#Mission to track the progress of British LIGHT CRUISER construction
+	POR_british_light_cruiser_construction_progress = {
+		
+		icon = generic_naval
+
+		allowed = {
+			original_tag = POR
+		}
+
+		visible = {
+			has_country_flag = POR_purchase_british_light_cruiser_flag
+		}
+		
+		modifier = {
+			civilian_factory_use = 1
+		}
+
+		days_remove = 546
+
+		cancel_trigger = {
+			OR = {
+				NOT = { country_exists = POR }
+				NOT = { country_exists = ENG }
+				ENG = {
+					OR = {
+						has_war_with = ROOT
+						has_civil_war = yes
+						has_capitulated = yes
+						NOT = { owns_state = 126 } #Owns London
+					}
+				}
+			}
+		}
+
+		#Fail
+		cancel_effect = {
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+				remove_opinion_modifier = {
+					target = POR
+					modifier = POR_bought_ships
+				}
+			}
+			remove_opinion_modifier = {
+				target = ENG
+				modifier = POR_sold_ships
+			}
+			remove_opinion_modifier = {
+				target = ENG
+				modifier = POR_ships_trade
+			}
+			clr_country_flag = POR_purchase_british_light_cruiser_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+
+		#Success
+		remove_effect = {
+			if = {
+				limit = { has_dlc = "Man the Guns" }
+				if = { 
+					limit = {
+						ENG = { has_tech = advanced_ship_hull_cruiser }
+					}
+					hidden_effect = { add_manpower = 1400 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Atlântico Class"	
+							type = ship_hull_cruiser_4
+							name_group = POR_CL_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_medium_battery_2
+								fixed_ship_anti_air_slot = ship_anti_air_2
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = cruiser_ship_engine_2
+								fixed_ship_armor_slot = empty
+								front_1_custom_slot = ship_anti_air_1
+								mid_1_custom_slot = ship_torpedo_1
+								mid_2_custom_slot = ship_airplane_launcher_1
+								rear_1_custom_slot = ship_light_medium_battery_2
+							}
+						}
+					}
+					create_ship = { type = ship_hull_cruiser_4 equipment_variant = "Atlântico Class" creator = ENG }
+				}
+				else_if = { 
+					limit = {
+						ENG = { has_tech = improved_ship_hull_cruiser }
+					}
+					hidden_effect = { add_manpower = 1200 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Atlântico Class"	
+							type = ship_hull_cruiser_3
+							name_group = POR_CL_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_medium_battery_2
+								fixed_ship_anti_air_slot = ship_anti_air_2
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = cruiser_ship_engine_2
+								fixed_ship_armor_slot = empty
+								front_1_custom_slot = ship_anti_air_1
+								mid_1_custom_slot = ship_torpedo_1
+								mid_2_custom_slot = ship_airplane_launcher_1
+								rear_1_custom_slot = ship_light_medium_battery_2
+							}
+						}
+					}
+					create_ship = { type = ship_hull_cruiser_3 equipment_variant = "Atlântico Class" creator = ENG }
+				}
+				else = {
+					hidden_effect = { add_manpower = 800 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Atlântico Class"	
+							type = ship_hull_cruiser_2
+							name_group = POR_CL_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_medium_battery_2
+								fixed_ship_anti_air_slot = ship_anti_air_2
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = cruiser_ship_engine_2
+								fixed_ship_armor_slot = empty
+								front_1_custom_slot = ship_anti_air_1
+								mid_1_custom_slot = ship_torpedo_1
+								mid_2_custom_slot = ship_airplane_launcher_1
+								rear_1_custom_slot = ship_light_medium_battery_2
+							}
+						}
+					}
+					create_ship = { type = ship_hull_cruiser_2 equipment_variant = "Atlântico Class" creator = ENG }
+				}
+			}
+			else = { #NO MTG
+				if = { 
+					limit = {
+						ENG = { has_tech = advanced_light_cruiser }
+					}
+					hidden_effect = { add_manpower = 1140 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Atlântico Class"
+							type = light_cruiser_4
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 4
+								ship_engine_upgrade = 3
+								ship_gun_upgrade = 4
+								ship_anti_air_upgrade = 3
+							}
+						}
+					}
+					create_ship = { type = light_cruiser_4 equipment_variant = "Atlântico Class" creator = ENG }
+				}
+				else_if = { 
+					limit = {
+						ENG = { has_tech = improved_light_cruiser }
+					}
+					hidden_effect = { add_manpower = 960 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Atlântico Class"
+							type = light_cruiser_3
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 4
+								ship_engine_upgrade = 2
+								ship_gun_upgrade = 3
+								ship_anti_air_upgrade = 3
+							}
+						}
+					}
+					create_ship = { type = light_cruiser_3 equipment_variant = "Atlântico Class" creator = ENG }
+				}
+				else_if = { 
+					limit = {
+						ENG = { has_tech = basic_light_cruiser }
+					}
+					hidden_effect = { add_manpower = 800 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Atlântico Class"
+							type = light_cruiser_2
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 3
+								ship_engine_upgrade = 2
+								ship_gun_upgrade = 3
+								ship_anti_air_upgrade = 2
+							}
+						}
+					}
+					create_ship = { type = light_cruiser_2 equipment_variant = "Atlântico Class" creator = ENG }
+				}
+				else = {
+					hidden_effect = { add_manpower = 600 }
+					ENG = {
+						create_equipment_variant = {
+							name = "Atlântico Class"
+							type = light_cruiser_1
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 2
+								ship_engine_upgrade = 1
+								ship_gun_upgrade = 3
+								ship_anti_air_upgrade = 2
+							}
+						}
+					}
+					create_ship = { type = light_cruiser_1 equipment_variant = "Atlântico Class" creator = ENG }
+				}
+			}
+
+			ENG = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+			}
+			country_event = lar_portugal_purchase_ships.6
+			set_country_flag = POR_ships_purchased_flag
+			clr_country_flag = POR_purchase_british_light_cruiser_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+	}
+
+	#Mission to track the progress of Italian LIGHT CRUISER construction
+	POR_italian_light_cruiser_construction_progress = {
+		
+		icon = generic_naval
+
+		allowed = {
+			original_tag = POR
+		}
+
+		visible = {
+			has_country_flag = POR_purchase_italian_light_cruiser_flag
+		}
+		
+		modifier = {
+			civilian_factory_use = 1
+		}
+
+		days_remove = 546
+
+		cancel_trigger = {
+			OR = {
+				NOT = { country_exists = POR }
+				NOT = { country_exists = ITA }
+				ITA = {
+					OR = {
+						has_war_with = ROOT
+						has_civil_war = yes
+						has_capitulated = yes
+						NOT = { owns_state = 2 } #Owns Rome
+					}
+				}
+			}
+		}
+
+		#On Activation
+		complete_effect ={
+			ITA = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = 1
+				}
+			}
+		}
+
+		#Fail
+		cancel_effect = {
+			ITA = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+				remove_opinion_modifier = {
+					target = POR
+					modifier = POR_bought_ships
+				}
+			}
+			remove_opinion_modifier = {
+				target = ITA
+				modifier = POR_sold_ships
+			}
+			remove_opinion_modifier = {
+				target = ITA
+				modifier = POR_ships_trade
+			}
+			clr_country_flag = POR_purchase_italian_light_cruiser_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+
+		#Success
+		remove_effect = {
+			if = {
+				limit = { has_dlc = "Man the Guns" }
+				if = { 
+					limit = {
+						ITA = { has_tech = advanced_ship_hull_cruiser }
+					}
+					hidden_effect = { add_manpower = 1400 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Atlântico Class"	
+							type = ship_hull_cruiser_4
+							name_group = POR_CL_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_medium_battery_2
+								fixed_ship_anti_air_slot = ship_anti_air_2
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = cruiser_ship_engine_2
+								fixed_ship_armor_slot = empty
+								front_1_custom_slot = ship_anti_air_1
+								mid_1_custom_slot = ship_torpedo_1
+								mid_2_custom_slot = ship_airplane_launcher_1
+								rear_1_custom_slot = ship_light_medium_battery_2
+							}
+						}
+					}
+					create_ship = { type = ship_hull_cruiser_4 equipment_variant = "Atlântico Class" creator = ITA }
+				}
+				else_if = { 
+					limit = {
+						ITA = { has_tech = improved_ship_hull_cruiser }
+					}
+					hidden_effect = { add_manpower = 1200 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Atlântico Class"	
+							type = ship_hull_cruiser_3
+							name_group = POR_CL_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_medium_battery_2
+								fixed_ship_anti_air_slot = ship_anti_air_2
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = cruiser_ship_engine_2
+								fixed_ship_armor_slot = empty
+								front_1_custom_slot = ship_anti_air_1
+								mid_1_custom_slot = ship_torpedo_1
+								mid_2_custom_slot = ship_airplane_launcher_1
+								rear_1_custom_slot = ship_light_medium_battery_2
+							}
+						}
+					}
+					create_ship = { type = ship_hull_cruiser_3 equipment_variant = "Atlântico Class" creator = ITA }
+				}
+				else = {
+					hidden_effect = { add_manpower = 800 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Atlântico Class"	
+							type = ship_hull_cruiser_2
+							name_group = POR_CL_HISTORICAL
+							parent_version = 0
+							allow_without_tech = yes
+							modules = {
+								fixed_ship_battery_slot = ship_light_medium_battery_2
+								fixed_ship_anti_air_slot = ship_anti_air_2
+								fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+								fixed_ship_radar_slot = empty
+								fixed_ship_engine_slot = cruiser_ship_engine_2
+								fixed_ship_armor_slot = empty
+								front_1_custom_slot = ship_anti_air_1
+								mid_1_custom_slot = ship_torpedo_1
+								mid_2_custom_slot = ship_airplane_launcher_1
+								rear_1_custom_slot = ship_light_medium_battery_2
+							}
+						}
+					}
+					create_ship = { type = ship_hull_cruiser_2 equipment_variant = "Atlântico Class" creator = ITA }
+				}
+			}
+			else = { #NO MTG
+				if = { 
+					limit = {
+						ITA = { has_tech = advanced_light_cruiser }
+					}
+					hidden_effect = { add_manpower = 1140 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Atlântico Class"
+							type = light_cruiser_4
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 4
+								ship_engine_upgrade = 3
+								ship_gun_upgrade = 4
+								ship_anti_air_upgrade = 3
+							}
+						}
+					}
+					create_ship = { type = light_cruiser_4 equipment_variant = "Atlântico Class" creator = ITA }
+				}
+				else_if = { 
+					limit = {
+						ITA = { has_tech = improved_light_cruiser }
+					}
+					hidden_effect = { add_manpower = 960 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Atlântico Class"
+							type = light_cruiser_3
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 4
+								ship_engine_upgrade = 2
+								ship_gun_upgrade = 3
+								ship_anti_air_upgrade = 3
+							}
+						}
+					}
+					create_ship = { type = light_cruiser_3 equipment_variant = "Atlântico Class" creator = ITA }
+				}
+				else_if = { 
+					limit = {
+						ITA = { has_tech = basic_light_cruiser }
+					}
+					hidden_effect = { add_manpower = 800 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Atlântico Class"
+							type = light_cruiser_2
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 3
+								ship_engine_upgrade = 2
+								ship_gun_upgrade = 3
+								ship_anti_air_upgrade = 2
+							}
+						}
+					}
+					create_ship = { type = light_cruiser_2 equipment_variant = "Atlântico Class" creator = ITA }
+				}
+				else = {
+					hidden_effect = { add_manpower = 600 }
+					ITA = {
+						create_equipment_variant = {
+							name = "Atlântico Class"
+							type = light_cruiser_1
+							allow_without_tech = yes
+							upgrades = {
+								ship_reliability_upgrade = 2
+								ship_engine_upgrade = 1
+								ship_gun_upgrade = 3
+								ship_anti_air_upgrade = 2
+							}
+						}
+					}
+					create_ship = { type = light_cruiser_1 equipment_variant = "Atlântico Class" creator = ITA }
+				}
+			}
+
+			ITA = {
+				add_offsite_building = {
+					type = industrial_complex
+					level = -1
+				}
+			}
+			country_event = lar_portugal_purchase_ships.6
+			set_country_flag = POR_ships_purchased_flag
+			clr_country_flag = POR_purchase_italian_light_cruiser_flag
+			clr_country_flag = POR_ships_purchase_in_progress_flag
+		}
+	}
+}
+
+POR_naval_blockade = {
+	POR_evade_blockade_with_portuguese_convoys = {
+
+		icon = generic_naval
+
+		allowed = {
+			NOT = { original_tag = POR }
+		}
+
+		visible = {
+			POR = {
+				has_completed_focus = POR_refuse_the_naval_blockade
+			}
+			NOT = { 
+				has_country_flag = POR_evade_blockade_flag 
+				has_country_flag = POR_cancel_evade_blockade_flag 
+			}
+		}
+		
+		available = {
+			num_of_civilian_factories > 1
+			POR = {
+				has_navy_size = {
+				    size > 49
+				    type = convoy
+				}
+				has_opinion = { target = ROOT value > -10 }
+			}
+		}
+
+		cost = 25
+		fire_only_once = yes
+		ai_will_do = {
+			base = 1
+		}
+
+		cancel_trigger = {
+			OR= {
+				NOT = { has_war_with = ENG }
+				has_war_with = POR
+				has_country_flag = POR_cancel_evade_blockade_flag
+				has_capitulated = yes
+			}
+		}
+
+		days_remove = -1
+
+		modifier = {
+			civilian_factory_use = 1
+		}
+
+		#Fail
+		cancel_effect = {
+			add_war_support = -0.1
+			POR = {
+				add_equipment_to_stockpile = {
+		            type = convoy_1
+		            amount = 50
+	       		}
+				add_offsite_building = { type = industrial_complex  level = -1 }
+			}
+			set_country_flag = POR_cancel_evade_blockade_flag
+			clr_country_flag = POR_evade_blockade_flag
+		}
+
+		#On Activation
+		complete_effect = {
+			add_war_support = 0.1
+			set_country_flag = POR_evade_blockade_flag
+			effect_tooltip = {
+				POR = { 
+					add_equipment_to_stockpile = {
+			            type = convoy_1
+			            amount = -50
+		       		}
+					add_offsite_building = { type = industrial_complex  level = 1 }
+				}
+			}
+			hidden_effect=  { 
+				POR = { 
+					country_event = lar_portugal_naval_blockade.2 
+					activate_targeted_decision = { 
+						target = ROOT 
+						decision = POR_portugal_cancel_blockade_evasion_for_country
+					}
+				}
+			}
+		}
+	}
+
+	POR_major_cancel_portuguese_blockade_evasion = {
+
+		icon = generic_break_treaty
+
+		available = {
+			has_country_flag = POR_evade_blockade_flag
+		}
+
+		cost = 0
+		fire_only_once = yes
+		ai_will_do = {
+			base = 0
+			modifier = {
+				add = 1
+				num_of_civilian_factories < 6
+			}
+		}
+
+		visible = {
+			has_country_flag = POR_evade_blockade_flag
+			NOT = { has_country_flag = POR_cancel_evade_blockade_flag }
+		}
+
+		complete_effect = {
+			add_war_support = -0.1
+			set_country_flag = POR_cancel_evade_blockade_flag
+			clr_country_flag = POR_evade_blockade_flag
+		}
+	}
+
+	POR_portugal_cancel_blockade_evasion_for_country = {
+
+		icon = generic_break_treaty
+
+		available = {
+			always = yes
+		}
+
+		cost = 0
+		fire_only_once = yes
+		ai_will_do = {
+			base = 0
+			modifier = {
+				add = 1
+				OR = {
+					has_equipment = {
+					    convoy_1 < 5
+					}
+					AND = {
+						has_opinion = { target = FROM value < -10 }
+						NOT = { has_war_with = FROM }
+					}
+				}
+			}
+		}
+
+		visible = {
+			original_tag = POR
+			country_exists = FROM
+			FROM = {
+           		has_country_flag = POR_evade_blockade_flag
+           		NOT = { 
+           			has_country_flag = POR_cancel_evade_blockade_flag
+           			has_war_with = POR
+           		}
+           	}
+		}		
+
+		complete_effect = {
+			FROM = {
+				add_war_support = -0.1
+				set_country_flag = POR_cancel_evade_blockade_flag
+				clr_country_flag = POR_evade_blockade_flag
+			}
+		}
+	}
+
+}
+
+POR_iberian_summit = {
+	POR_iberian_summit_pro_axis = {
+		icon = eng_trade_unions_support
+
+		allowed = {
+			OR = {
+				original_tag = POR
+				tag = SPA
+			}
+		}
+
+		available = {		
+			POR = { has_war = no }
+			SPA = { has_war = no }
+			NOT = { has_global_flag = POR_iberian_summit_in_progress_flag }
+		}
+
+		visible = {
+			NOT = { has_global_flag = POR_iberian_summit_pro_axis_flag }
+			country_exists = POR
+			POR = { 
+				is_in_faction = no
+				has_completed_focus = POR_iberian_summit
+				NOT = { has_government = communism }
+				NOT = { has_government = democratic }
+			}
+			country_exists = SPA
+			SPA = {
+				is_in_faction = no
+				OR = {
+					has_completed_focus = SPA_the_phalanx_ascendant
+					AND = {
+						has_completed_focus = SPA_unify_the_nationalist_front
+						NOT = { has_completed_focus = SPA_the_iberian_pact }
+					}
+				}
+			}
+			GER = { 
+				is_faction_leader = yes 
+				has_government = fascism
+				has_capitulated = no
+			}
+		}
+
+		cost = 50
+		fire_only_once = yes
+		days_remove = 1
+		ai_will_do = {
+			base = 0
+			modifier = {
+				add = 1
+				has_completed_focus = POR_send_assistance
+				OR = {
+					GER = {
+						has_war = yes 
+						OR = {
+							alliance_strength_ratio > 0.75
+							any_war_score > 40
+						}
+					}
+					has_opinion = { target = GER value > 0 }		
+				}
+			}
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
+		}
+
+		complete_effect = {
+			set_global_flag = POR_iberian_summit_pro_axis_flag
+			set_global_flag = POR_iberian_summit_in_progress_flag
+			set_country_flag = POR_iberian_summit_initiator_flag
+			set_variable = { global.POR_iberian_summit_target = GER } 
+			set_variable = { global.POR_iberian_summit_spanish_tag = SPA }
+			if = {
+				limit = {
+					tag = POR
+				}
+				SPA = { 
+					country_event = { id = lar_portugal_iberian_summit.1 hours = 18 random_hours = 6 }
+				}
+			}
+			else = {
+				POR = { 
+					country_event = { id = lar_portugal_iberian_summit.1 hours = 18 random_hours = 6 } 
+				}
+			}
+		}	
+	}
+
+	POR_iberian_summit_pro_allies = {
+		icon = eng_trade_unions_support
+
+		allowed = {
+			OR = {
+				original_tag = POR
+				tag = SPA
+				tag = SPD
+			}
+		}
+
+		available = {		
+			POR = { has_war = no }
+			if = {
+				limit = {
+					country_exists = SPA #This is the prio
+				}
+				SPA = { has_war = no }
+			}
+			else_if = {
+				limit = {
+					country_exists = SPD
+				}
+				SPD = { has_war = no }
+			}
+			else = {
+				SPR = { has_war = no }
+			}
+			NOT = { has_global_flag = POR_iberian_summit_in_progress_flag }
+		}
+
+		visible = {
+			NOT = { has_global_flag = POR_iberian_summit_pro_allies_flag }
+			country_exists = POR
+			POR = {
+				is_in_faction = no
+				has_completed_focus = POR_iberian_summit
+				NOT = { has_government = fascism }
+				NOT = { has_government = communism }
+			}
+			if = {
+				limit = {
+					country_exists = SPA #This is the prio
+				}
+				SPA = {
+					is_in_faction = no
+					has_completed_focus = SPA_unify_the_nationalist_front
+					NOT = { has_completed_focus = SPA_the_iberian_pact }
+				}
+			}
+			else = {
+				country_exists = SPD
+				SPD = {
+					is_in_faction = no
+					has_completed_focus = SPR_maintain_the_second_republic
+					has_government = democratic
+				}
+			}
+			ENG = { 
+				is_faction_leader = yes 
+				has_government = democratic
+				has_capitulated = no
+			}
+		}
+
+		cost = 50
+		fire_only_once = yes
+		days_remove = 1
+		ai_will_do = { 
+			base = 0
+			modifier = {
+				add = 1
+				POR = {
+					has_completed_focus = POR_allow_free_elections
+				}					
+				OR = {
+					ENG = {
+						has_war = yes 
+						OR = {
+							alliance_strength_ratio > 0.75
+							any_war_score > 40
+						}
+					}
+					has_opinion = { target = ENG value > 0 }		
+				}
+			}
+			modifier = {
+				factor = 0
+				is_historical_focus_on = yes
+			}
+		}
+
+		complete_effect = {
+			set_global_flag = POR_iberian_summit_pro_allies_flag
+			set_global_flag = POR_iberian_summit_in_progress_flag
+			set_country_flag = POR_iberian_summit_initiator_flag
+			set_variable = { global.POR_iberian_summit_target = ENG }
+			if = {
+				limit = { country_exists = SPA }
+				set_variable = { global.POR_iberian_summit_spanish_tag = SPA }
+			} 
+			else = {
+				set_variable = { global.POR_iberian_summit_spanish_tag = SPD }
+			}
+			if = {
+				limit = { tag = POR }
+				41 = {
+					owner = { country_event = { id = lar_portugal_iberian_summit.5 hours = 18 random_hours = 6 } }
+				}
+			}
+			else = {
+				POR = { 
+					country_event = { id = lar_portugal_iberian_summit.5 hours = 18 random_hours = 6 }
+				}
+			}
+		}	
+	}
+	#Timed Decision for delaying proposal
+	POR_iberian_summit_proposal_delayed = {
+		icon = generic_political_discourse
+		
+		allowed = {
+			OR = {
+				tag = POR
+				tag = SPD
+				tag = SPA
+			}
+		}
+
+		visible = {
+			has_global_flag = POR_iberian_summit_proposal_delayed_flag 
+		}
+
+		fire_only_once = no
+
+		days_remove = 180
+
+		modifier = {
+			political_power_gain = -0.2
+		}
+
+		cancel_trigger = {
+			OR = {
+				NOT = { country_exists = global.POR_iberian_summit_target }
+				var:global.POR_iberian_summit_target = { is_faction_leader = no }
+				NOT = { country_exists = POR }
+				POR = {
+					OR = { 
+						has_war = yes 
+						is_in_faction = yes
+					}
+				}
+				NOT = { country_exists = global.POR_iberian_summit_spanish_tag }
+				var:global.POR_iberian_summit_spanish_tag = {
+					OR = {
+						has_war = yes
+						is_in_faction = yes
+					}
+				}
+			}
+		}
+
+		#On Activation
+		complete_effect = {
+			var:global.POR_iberian_summit_target = {
+				add_opinion_modifier = {
+					target = ROOT
+					modifier = POR_iberian_summit_diplomatic_approach
+				}
+			}
+		}
+
+		#Fail
+		cancel_effect = {
+			remove_opinion_modifier = {	target = POR modifier = POR_iberian_summit_working_together	}
+			var:global.POR_iberian_summit_target = {
+				remove_opinion_modifier = { target = POR modifier = POR_iberian_summit_diplomatic_approach }
+			}
+			if = { 
+				limit = { country_exists = SPA }
+				remove_opinion_modifier = {	target = SPA modifier = POR_iberian_summit_working_together	}
+				var:global.POR_iberian_summit_target = {
+					remove_opinion_modifier = { target = SPA modifier = POR_iberian_summit_diplomatic_approach }
+				}
+			}
+			else = {
+				remove_opinion_modifier = {	target = SPD modifier = POR_iberian_summit_working_together	}
+				var:global.POR_iberian_summit_target = {
+					remove_opinion_modifier = { target = SPA modifier = POR_iberian_summit_diplomatic_approach }
+				}
+			}
+			
+			clr_global_flag = POR_iberian_summit_in_progress_flag
+			clr_global_flag = POR_iberian_summit_proposal_delayed_flag
+			clr_country_flag = POR_iberian_summit_initiator_flag  
+			clear_variable = global.POR_iberian_summit_target
+		}
+
+		#Success
+		remove_effect = {
+			if = {
+				limit = {
+					has_country_flag = POR_iberian_summit_initiator_flag
+				}
+				if = {
+					limit = {
+						check_variable = {
+						    var = global.POR_iberian_summit_target
+						    value = GER
+						    compare = equals
+						}
+					}
+					var:global.POR_iberian_summit_target = { 
+						country_event = { id = lar_portugal_iberian_summit.4 hours = 8 random_hours = 4 }
+					}
+				}
+				else = {
+					var:global.POR_iberian_summit_target = { 
+						country_event = { id = lar_portugal_iberian_summit.8 hours = 8 random_hours = 4 }
+					}
+				}
+			}
+			clr_global_flag = POR_iberian_summit_in_progress_flag
+			clr_global_flag = POR_iberian_summit_proposal_delayed_flag
+			clr_country_flag = POR_iberian_summit_initiator_flag
+		}
+	}
+}
+
+POR_monarchist_cause = {
+
+	POR_stir_monarchist_sentiment_in_brazil = {
+		icon = generic_political_discourse
+
+		allowed = {
+			has_dlc = "La Resistance"
+			original_tag = POR
+		}
+
+		available = {
+			BRA = { 
+				has_war = no 
+				IF = {
+					limit = {
+						has_dlc = "Trial of Allegiance"
+					}
+				
+					NOT = {
+						has_country_flag = BRA_rejected_monarchism
+						has_completed_focus = BRA_romanticize_the_old_empire
+					}
+				}
+			}
+		}
+
+		cost = 25
+		fire_only_once = no
+
+		ai_will_do = {
+			base = 1
+		}
+		visible = {
+			has_completed_focus = POR_a_royal_wedding
+			NOT = { has_completed_focus = POR_the_empire_of_brazil }
+			country_exists = BRA
+		}
+
+		cancel_trigger = {
+			OR = {
+				has_completed_focus = POR_the_empire_of_brazil
+				has_war_with = BRA
+				BRA = { neutrality < -0.15 }
+			}
+		}
+
+		cancel_effect = {
+			BRA = {
+				clr_country_flag = POR_portugal_stirring_brazilian_monarchists_flag
+				set_country_flag = POR_brazilian_monarchists_stirred_flag
+			}
+		}
+
+		modifier = {
+			political_power_gain = -0.5
+		}
+		days_remove = 180
+
+		remove_effect = {
+			BRA = {
+				clr_country_flag = POR_portugal_stirring_brazilian_monarchists_flag
+				set_country_flag = POR_brazilian_monarchists_stirred_flag
+			}
+		}
+
+		complete_effect = {
+			custom_effect_tooltip = POR_stir_monarchist_sentiment_in_brazil_tt
+			BRA = { 
+				activate_decision = POR_portugal_promoting_monarchist_cause_in_brazil
+				set_country_flag = POR_portugal_stirring_brazilian_monarchists_flag 
+				country_event = { id = lar_portugal_promote_monarchist_cause.1 }
+			}
+		}
+	}
+
+	#Mission for BRA when POR starts promoting monarchist cause in BRA.
+	POR_portugal_promoting_monarchist_cause_in_brazil = {
+		icon = generic_civil_support
+
+		allowed = {
+			has_dlc = "La Resistance"
+			original_tag = BRA
+		}
+
+		visible = {
+			has_country_flag = POR_portugal_stirring_brazilian_monarchists_flag
+		}
+
+		cancel_trigger = {
+			OR = {
+				NOT = { has_country_flag = POR_portugal_stirring_brazilian_monarchists_flag }
+				POR = { has_completed_focus = POR_the_empire_of_brazil }
+				neutrality < -0.15
+				has_war_with = POR
+			}
+		}
+
+		fire_only_once = no
+
+		modifier = {
+			neutrality_drift = 0.1
+			stability_weekly = -0.01
+		}
+
+		days_remove = 180
+	}
+
+	#Decision for BRA to fight brazilian monarchists
+	POR_repress_brazilian_monarchists = {
+		icon = oppression
+
+		allowed = {
+			has_dlc = "La Resistance"
+			original_tag = BRA
+		}
+
+		available = {
+			neutrality < 1
+		}
+
+		cost = 25
+		fire_only_once = no
+
+		ai_will_do = {
+			factor = 0
+		}
+		visible = {
+			OR = {
+				has_country_flag = POR_portugal_stirring_brazilian_monarchists_flag
+				has_country_flag = POR_brazilian_monarchists_stirred_flag
+			}
+			country_exists = POR
+			POR = { NOT = { has_completed_focus = POR_the_empire_of_brazil } }		
+		}
+
+		cancel_trigger = {
+			POR = { has_completed_focus = POR_the_empire_of_brazil }
+		}
+
+		modifier = {
+			stability_factor = -0.05
+			political_power_gain  = -0.5
+			neutrality_drift = -0.1
+		}
+
+		days_remove = 180
+
+		remove_effect = {
+			clr_country_flag = POR_brazilian_monarchists_stirred_flag
+		}
+	}
+
+	#Decision to boost unaligned popularity in Portugal 
+	POR_stir_monarchist_sentiment_in_portugal = {
+		icon = generic_political_discourse
+
+		allowed = {
+			has_dlc = "La Resistance"
+			original_tag = POR
+		}
+
+		available = {
+			neutrality < 1
+		}
+
+		cost = 25
+		fire_only_once = no
+
+		ai_will_do = {
+			base = 1
+		}
+		visible = {
+			has_completed_focus = POR_a_royal_wedding
+			NOT = { has_completed_focus = POR_restoration_of_the_monarchy }
+		}
+
+		cancel_trigger = {
+			has_completed_focus = POR_restoration_of_the_monarchy
+		}
+
+		modifier = {
+			political_power_gain = -0.5
+			neutrality_drift = 0.1
+			stability_weekly = -0.01
+		}
+		days_remove = 180
+	}
+}
+
+POR_prospect_for_resources = {
+	POR_develop_lisbon_tungsten_deposits = { #112
+		
+		icon = tungsten
+
+		allowed = {
+
+		}
+
+		highlight_states = {
+ highlight_state_targets = {
+			state = 112
+		} 
+}
+
+		available = {
+			has_completed_focus = POR_extraction_industries
+			num_of_civilian_factories_available_for_projects > 2
+			owns_state = 112
+			controls_state = 112
+		}
+
+		visible = {
+			owns_state = 112
+			controls_state = 112
+			112 = {
+				NOT = {	has_state_flag = POR_lisbon_tungsten_developed_flag }
+			}
+		}
+
+		cost = 25
+		days_remove = 90
+		fire_only_once = yes
+
+		modifier = {
+			civilian_factory_use = 3
+		}
+
+		remove_effect = {
+			112 = {	set_state_flag = POR_lisbon_tungsten_developed_flag }
+			112 = {
+				add_resource = {
+					type = tungsten
+					amount = 10
+				}
+			}
+		}
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				has_political_power < 200
+				factor = 0
+			}
+		}
+	}
+
+	POR_develop_santarem_chromium_deposits = { #795
+		
+		icon = chromium
+
+		allowed = {
+
+		}
+
+		highlight_states = {
+ highlight_state_targets = {
+			state = 795
+		} 
+}
+
+		available = {
+			has_completed_focus = POR_extraction_industries
+			num_of_civilian_factories_available_for_projects > 1
+			owns_state = 795
+			controls_state = 795
+		}
+
+		visible = {
+			owns_state = 795
+			controls_state = 795
+			795 = {
+				NOT = {
+					has_state_flag = { 
+						flag = POR_santarem_chromium_developed_flag
+						value = 5
+					}
+				}
+			}
+		}
+
+		cost = 25
+		days_remove = POR_santarem_chromium_duration
+
+		modifier = {
+			civilian_factory_use = 1
+		}
+
+		remove_effect = {
+			add_to_variable = { var = POR_santarem_chromium_duration value = 30 }
+			795 = {
+				if = {
+					limit = {
+						NOT = {
+							has_state_flag = POR_santarem_chromium_developed_flag
+						}
+					}
+					set_state_flag = {
+						flag = POR_santarem_chromium_developed_flag
+						value = 1
+					}
+				}
+				else = {
+					modify_state_flag = {
+						flag = POR_santarem_chromium_developed_flag
+						value = 1
+					}
+				}
+			}
+			795 = {
+				add_resource = {
+					type = chromium
+					amount = 2
+				}
+			}
+		}
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				has_political_power < 200
+				factor = 0
+			}
+		}
+
+		complete_effect = {
+			if = {
+				limit = {
+					check_variable = { var = POR_santarem_chromium_duration value = 30 compare = less_than }
+				}
+				set_variable = { var = POR_santarem_chromium_duration value = 15 }
+			}
+		}
+	}
+}
+
+
+POR_the_spanish_civil_war = {
+	POR_fight_alongside_the_republic = {
+		icon = generic_prepare_civil_war
+
+		available = {
+			has_manpower > 10000
+			has_stability > 0.5
+			OR = {
+				AND = {
+					country_exists = SPA
+					NOT = { has_war_with = SPA }
+				}
+				AND = {
+					country_exists = SPC
+					NOT = { has_war_with = SPC }
+				}
+				AND = {
+					country_exists = SPB
+					NOT = { has_war_with = SPB }
+				}
+			}
+		}
+
+		cost = 0
+		fire_only_once = yes
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				OR = {
+					has_stability < 0.3
+					has_manpower < 50000
+				}
+				factor = 0
+			}
+		}
+
+		visible = {
+			SPR_scw_in_progress = yes
+			country_exists = SPD
+			NOT = { has_war_with = SPD }
+			has_completed_focus = POR_they_need_our_help
+		}
+		complete_effect = {
+			hidden_effect = {
+				set_country_flag = supports_SPD_flag
+			}	
+			if = {
+				limit = { country_exists = SPA }
+				add_to_war = { targeted_alliance = SPD enemy = SPA hostility_reason = asked_to_join }
+			}
+			if = {
+				limit = { country_exists = SPC }
+				add_to_war = { targeted_alliance = SPD enemy = SPC hostility_reason = asked_to_join }
+			}
+			if = {
+				limit = { country_exists = SPB }
+				add_to_war = { targeted_alliance = SPD enemy = SPB hostility_reason = asked_to_join }
+			}
+			effect_tooltip = {
+				give_military_access = SPD
+				SPD = { give_military_access = ROOT }
+			}
+			hidden_effect = {
+				diplomatic_relation = {
+					country = SPD
+					relation = military_access
+					active = yes
+				}
+				SPD = {
+					diplomatic_relation = {
+						country = POR
+						relation = military_access
+						active = yes
+					}
+				}
+			}
+		}
+	}
+
+	POR_fight_alongside_the_nationalists = {
+		icon = generic_prepare_civil_war
+
+		available = {
+			has_manpower > 10000
+			has_stability > 0.5
+			OR = {
+				AND = {
+					country_exists = SPD
+					NOT = { has_war_with = SPD }
+				}
+				AND = {
+					country_exists = SPC
+					NOT = { has_war_with = SPC }
+				}
+				AND = {
+					country_exists = SPB
+					NOT = { has_war_with = SPB }
+				}
+			}
+		}
+
+		cost = 0
+		fire_only_once = yes
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				OR = {
+					has_stability < 0.3
+					has_manpower < 50000
+				}
+				factor = 0
+			}
+		}
+
+		visible = {
+			SPR_scw_in_progress = yes
+			country_exists = SPA
+			NOT = { has_war_with = SPA }
+			has_completed_focus = POR_send_assistance
+		}
+		complete_effect = {
+			hidden_effect = {
+				set_country_flag = supports_SPA_flag
+			}	
+			if = {
+				limit = { country_exists = SPD }
+				add_to_war = { targeted_alliance = SPA enemy = SPD hostility_reason = asked_to_join }
+			}
+			if = {
+				limit = { country_exists = SPC }
+				add_to_war = { targeted_alliance = SPA enemy = SPC hostility_reason = asked_to_join }
+			}
+			if = {
+				limit = { country_exists = SPB }
+				add_to_war = { targeted_alliance = SPA enemy = SPB hostility_reason = asked_to_join }
+			}
+			effect_tooltip = {
+				give_military_access = SPA
+				SPA = { give_military_access = ROOT }
+			}
+			hidden_effect = {
+				diplomatic_relation = {
+					country = SPA
+					relation = military_access
+					active = yes
+				}
+				SPA = {
+					diplomatic_relation = {
+						country = POR
+						relation = military_access
+						active = yes
+					}
+				}
+			}
+		}
+	}
+
+	POR_fight_alongside_the_carlists = {
+		icon = generic_prepare_civil_war
+
+		available = {
+			has_manpower > 10000
+			has_stability > 0.5
+			OR = {
+				AND = {
+					country_exists = SPD
+					NOT = { has_war_with = SPD }
+				}
+				AND = {
+					country_exists = SPC
+					NOT = { has_war_with = SPC }
+				}
+				AND = {
+					country_exists = SPA
+					NOT = { has_war_with = SPA }
+				}
+			}
+		}
+
+		cost = 0
+		fire_only_once = yes
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				OR = {
+					has_stability < 0.3
+					has_manpower < 50000
+				}
+				factor = 0
+			}
+		}
+
+		visible = {
+			SPR_scw_in_progress = yes
+			country_exists = SPB
+			NOT = { has_war_with = SPB }
+			has_completed_focus = POR_join_the_carlist_fight
+		}
+		complete_effect = {
+			hidden_effect = {
+				set_country_flag = supports_SPB_flag
+			}	
+			if = {
+				limit = { country_exists = SPD }
+				add_to_war = { targeted_alliance = SPB enemy = SPD hostility_reason = asked_to_join }
+			}
+			if = {
+				limit = { country_exists = SPC }
+				add_to_war = { targeted_alliance = SPB enemy = SPC hostility_reason = asked_to_join }
+			}
+			if = {
+				limit = { country_exists = SPA }
+				add_to_war = { targeted_alliance = SPB enemy = SPA hostility_reason = asked_to_join }
+			}
+			effect_tooltip = {
+				give_military_access = SPB
+				SPB = { give_military_access = ROOT }
+			}
+			hidden_effect = {
+				diplomatic_relation = {
+					country = SPB
+					relation = military_access
+					active = yes
+				}
+				SPB = {
+					diplomatic_relation = {
+						country = POR
+						relation = military_access
+						active = yes
+					}
+				}
+			}
+		}
+	}
+}

--- a/common/decisions/categories/POR_decision_categories.txt
+++ b/common/decisions/categories/POR_decision_categories.txt
@@ -1,0 +1,121 @@
+################
+##### POR ######
+################
+
+POR_overseas_provinces = {
+	
+	icon = saf_anti_colonialist_crusade
+
+	allowed = {
+		original_tag = POR
+		has_dlc = "La Resistance"
+	}
+
+	visible = {
+		
+	}
+}
+
+POR_arms_purchases = {
+	allowed = {
+		original_tag = POR
+		has_dlc = "La Resistance"
+	}
+	visible = {
+		OR = {
+			has_completed_focus = POR_british_guns
+			has_completed_focus = POR_second_navy_reequipment
+		}
+	}
+}
+
+POR_naval_blockade = {
+
+	picture = GFX_decision_cat_naval_blockade
+
+	icon = generic_political_actions
+
+	allowed = {
+		has_dlc = "La Resistance"
+	}
+	visible = {
+		OR = {
+			AND = {
+				has_war_with = ENG
+				NOT = {has_war_with = POR }
+			}
+			original_tag = POR
+		}
+		POR = {
+			has_completed_focus = POR_refuse_the_naval_blockade
+		}	
+	}
+}
+
+POR_iberian_summit = { 
+	icon = GFX_decision_cat_iberian_summit
+	allowed = {
+		has_dlc = "La Resistance"
+		OR = {
+			tag = POR
+			tag = SPD
+			tag = SPA
+		}
+	}
+	visible = {
+		is_in_faction = no
+		has_global_flag = scw_over
+		country_exists = POR
+		OR = {
+			country_exists = SPA
+			country_exists = SPD
+		}
+		OR = {
+			country_exists = GER
+			country_exists = ENG
+		}
+	}
+}
+
+POR_monarchist_cause = {
+	icon = generic_monarchism
+	allowed = {
+		has_dlc = "La Resistance"
+		OR = {
+			tag = POR
+			tag = BRA
+		}
+	}
+	visible = {
+		POR = { 
+			has_completed_focus = POR_a_royal_wedding
+		}
+	}
+}
+
+POR_prospect_for_resources = {
+	icon = generic_prospect_for_resources
+	allowed = {
+		has_dlc = "La Resistance"
+		tag = POR
+	}
+	visible = { 
+		has_completed_focus = POR_extraction_industries
+	}
+}
+
+POR_the_spanish_civil_war = {
+	icon = spr_civil_war_offensives
+	allowed = {
+		has_dlc = "La Resistance"
+		tag = POR
+	}
+	visible = { 
+		SPR_scw_in_progress = yes
+		OR = {
+			has_completed_focus = POR_they_need_our_help
+			has_completed_focus = POR_send_assistance
+			has_completed_focus = POR_join_the_carlist_fight
+		}
+	}
+}

--- a/common/military_industrial_organization/organizations/POR_organization.txt
+++ b/common/military_industrial_organization/organizations/POR_organization.txt
@@ -360,6 +360,36 @@ POR_ogme_organization = {
 		tag = POR
 	}
 
+	add_trait = { 
+		token = GRE_royal_hellenic_shipyards
+		name = POR_mechanized_mio
+		icon = GFX_generic_mio_department_icon_mechanized_production
+		special_trait_background = yes
+
+		position = { x = 9 y = 1 }
+		
+		visible = {
+			FROM = { original_tag = POR }
+		}
+
+		available = {
+			
+		}
+
+		limit_to_equipment_type = { mechanized_equipment motorized_equipment }
+
+		production_bonus = {
+			production_cost_factor = -0.05
+			
+		}
+		equipment_bonus = {
+			armor_value = 0.1
+		}
+	}
+
+
+
+
 	available = {
 		if = {
 			limit = {

--- a/common/national_focus/portugal.txt
+++ b/common/national_focus/portugal.txt
@@ -64,7 +64,7 @@ focus_tree = {
 		y = 1
 
 		relative_position_id = POR_colonial_assimilation_policy
-		cost = 8
+		cost = 5
 		search_filters = {FOCUS_FILTER_MANPOWER}
 		completion_reward = {
 			add_ideas = POR_colonial_army
@@ -439,7 +439,7 @@ focus_tree = {
 		y = 1
 
 		relative_position_id = POR_develop_south_angola
-		cost = 10
+		cost = 5
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_OIL}
 		completion_reward = {
 			796 = {
@@ -616,7 +616,7 @@ focus_tree = {
 		y = 1
 
 		relative_position_id = POR_instituto_superior_tecnico
-		cost = 8
+		cost = 10
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}
 		completion_reward = {
 			IF = {
@@ -626,7 +626,10 @@ focus_tree = {
 				custom_effect_tooltip = available_mio_tt
 				show_mio_tooltip = POR_ogme_organization
 				mio:POR_ogme_organization = {
-					add_mio_funds = 500
+					add_mio_size = 3
+				}
+				mio:POR_ogme_organization = {
+					unlock_mio_trait_tooltip = "OGME"
 				}
 			}
 			ELSE = {
@@ -675,7 +678,7 @@ focus_tree = {
 		y = 1
 
 		relative_position_id = POR_instituto_superior_tecnico
-		cost = 10
+		cost = 5
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}
 		completion_reward = {
 			if = {
@@ -833,7 +836,7 @@ focus_tree = {
 		y = 1
 
 		relative_position_id = POR_roads_bridges_and_dams
-		cost = 8
+		cost = 5
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_CHROMIUM FOCUS_FILTER_TUNGSTEN}
 		completion_reward = {
 			if = {
@@ -847,7 +850,7 @@ focus_tree = {
 			179 = {
 				add_resource = {
 					type = steel
-					amount = 4
+					amount = 16
 				}
 			}
 			if = {
@@ -978,10 +981,10 @@ focus_tree = {
 		search_filters = {FOCUS_FILTER_RESEARCH FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
 			add_tech_bonus = {
-				name = POR_military_vehicles
-			    bonus = 1.0
-			    uses = 1
-			    category = motorized_equipment
+				name = motorized_bonus
+				ahead_reduction = 1
+				bonus = 0.75
+				category = motorized_equipment
 			}
 
 			if = {
@@ -1210,6 +1213,12 @@ focus_tree = {
 		cost = 10
 		search_filters = {FOCUS_FILTER_RESEARCH FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
+
+			set_technology = {
+				basic_small_airframe = 2
+			}
+
+
 			add_tech_bonus = {
 				name = POR_light_aircraft_focus
 			    bonus = 1.0
@@ -1265,8 +1274,8 @@ focus_tree = {
 			add_tech_bonus = {
 				name = POR_advanced_light_aircraft
 			    bonus = 1.0
-			    uses = 1
-			    category = light_air
+			    uses = 2
+			    category = air_equipment
 			}
 			air_experience = 50
 			add_ideas = POR_advanced_light_aircraft
@@ -1303,12 +1312,12 @@ focus_tree = {
 		y = 1
 
 		relative_position_id = POR_instituto_superior_tecnico
-		cost = 10
+		cost = 5
 		search_filters = {FOCUS_FILTER_RESEARCH}
 		completion_reward = {
 			add_tech_bonus = {
 				name = POR_industrial_modernization
-			    bonus = 1.0
+			    bonus = 1
 			    uses = 2
 			    category = industry
 			}
@@ -1389,7 +1398,7 @@ focus_tree = {
 		y = 2
 
 		relative_position_id = POR_continue_the_public_works
-		cost = 10
+		cost = 5
 		search_filters = {FOCUS_FILTER_INDUSTRY}
 		completion_reward = {
 			if = {
@@ -2073,6 +2082,7 @@ focus_tree = {
 				name = POR_metropolitan_army
 			    bonus = 1.0
 			    uses = 2
+				ahead_reduction = 0.5
 			    category = infantry_weapons
 				category = armor
 				category = artillery
@@ -2332,7 +2342,7 @@ focus_tree = {
 		y = 1
 
 		relative_position_id = POR_staff_wargames
-		cost = 8
+		cost = 10
 
 		search_filters = {FOCUS_FILTER_RESEARCH}
 
@@ -2402,7 +2412,7 @@ focus_tree = {
 		y = 1
 
 		relative_position_id = POR_popular_front
-		cost = 10
+		cost = 5
 		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_WAR_SUPPORT FOCUS_FILTER_MANPOWER}
 		completion_reward = {
 			add_popularity = {
@@ -2940,7 +2950,7 @@ focus_tree = {
 		y = 1
 
 		relative_position_id = POR_popular_front
-		cost = 10
+		cost = 5
 		completion_reward = {
 			mark_focus_tree_layout_dirty = yes
 			if = {
@@ -4020,7 +4030,7 @@ focus_tree = {
 			}
 		}
 		relative_position_id = POR_support_the_spanish_republic
-		cost = 10
+		cost = 5
 		completion_reward = {
 			mark_focus_tree_layout_dirty = yes
 			every_other_country = {
@@ -4113,6 +4123,7 @@ focus_tree = {
 		relative_position_id = POR_strict_neutrality_in_the_spanish_civil_war
 		cost = 10
 		completion_reward = {
+			activate_advisor = POR_maria_lamas
 			unlock_decision_tooltip = POR_buy_aa_in_britain
 			unlock_decision_tooltip = POR_buy_at_in_britain
 		}
@@ -4213,7 +4224,7 @@ focus_tree = {
 	focus = {
 		id = POR_allow_free_elections
 		available = {
-			democratic > 0.5
+			democratic > 0.4
 			has_war = no
 		}
 		prerequisite = { focus = POR_british_industrial_investments }
@@ -4634,7 +4645,7 @@ focus_tree = {
 			}
 		}
 		relative_position_id = POR_estado_novo
-		cost = 10
+		cost = 5
 		completion_reward = {
 			mark_focus_tree_layout_dirty = yes
 			SPA = {
@@ -4677,7 +4688,7 @@ focus_tree = {
 		y = 1
 
 		relative_position_id = POR_support_the_spanish_nationalists
-		cost = 10
+		cost = 5
 		completion_reward = {
 			add_ideas = por_portuguese_legion
 		}
@@ -4924,7 +4935,7 @@ focus_tree = {
 		y = 0
 
 		relative_position_id = POR_observation_mission
-		cost = 10
+		cost = 5
 		completion_reward = {
 			add_manpower = -3000
 			add_equipment_to_stockpile = {
@@ -5294,7 +5305,7 @@ focus_tree = {
 		y = 1
 
 		relative_position_id = POR_national_syndicalism
-		cost = 10
+		cost = 5
 		completion_reward = {
 			remove_ideas = POR_estado_novo
 			every_country = {
@@ -5509,13 +5520,7 @@ focus_tree = {
 			#	add_core_of = ROOT
 			#}
 			add_ideas = POR_the_fifth_empire
-			remove_ideas = POR_unstable_republic
-			if = {
-				limit = { is_in_faction = yes }
-				leave_faction = yes
-			}
-			set_rule = { can_create_factions = yes }
-			set_rule = { can_join_factions = no }
+			remove_ideas = POR_unstable_republic						
 			every_other_country = {
 				limit = {
 					NOT = { is_puppet_of = ROOT }
@@ -5524,8 +5529,7 @@ focus_tree = {
 					target = ROOT
 					modifier = POR_the_fifth_empire_has_threatening_ambitions
 				}
-				send_embargo = ROOT
-				custom_effect_tooltip = embargo_relation_tt
+				
 			}
 			set_cosmetic_tag = POR_empire
 			if = {

--- a/localisation/english/replace/r56e_equipment_l_english.yml
+++ b/localisation/english/replace/r56e_equipment_l_english.yml
@@ -369,4 +369,7 @@ l_english:
 
  HOL_hih_siderius_organization: "Enkas"
 
+ POR_mechanized_mio: "OGME"
+ 
+
 #####---------------------------------------------------------------------End


### PR DESCRIPTION
- Military factory focuses unlock mio traits or give research bonuses
- Strict neutrality tree first focus is shorter. Buying british guns focus now gives you an advisor
- Focus to flip your ideology requires 40% support instead of 50%
- Support Nationalist spain branch first focus is shorter. Fifth empire no longer blocks you from factions and embargos everybody. 
- Colonial tree decisions no longer cost 0.20 daily pp for 730 days, but still require 730 days to integrate colonies.
- Oil focus is shortened
- Extraction focus gives 16 steel instead of 4
