### PR TITLE
TCDTF Germany Nerfs

### DIFF
--- a/common/national_focus/germany.txt
+++ b/common/national_focus/germany.txt
@@ -136,7 +136,7 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_INDUSTRY FOCUS_FILTER_STABILITY FOCUS_FILTER_POLITICAL_CHARACTER }
 
 		completion_reward = {
-
+			add_ideas = civilian_economy
 			add_stability = -0.1
 			if = {
 				limit = {
@@ -313,10 +313,10 @@ focus_tree = {
 						include_locked = yes
 					}
 				}
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
 					type = industrial_complex
-					level = 2
+					level = 1
 					instant_build = yes
 				}
 			}
@@ -605,10 +605,10 @@ focus_tree = {
 						include_locked = yes
 					}
 				}
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
 					type = industrial_complex
-					level = 2
+					level = 1
 					instant_build = yes
 				}
 			}
@@ -621,10 +621,10 @@ focus_tree = {
 						include_locked = yes
 					}
 				}
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
 					type = arms_factory
-					level = 2
+					level = 1
 					instant_build = yes
 				}
 			}
@@ -878,11 +878,11 @@ focus_tree = {
 			}
 			if = {
 				limit = {
-					978 = { #Baden
+					923 = { #Baden
 						is_owned_and_controlled_by = ROOT
 					}
 				}
-				978 = { set_state_category = metropolis }
+				923 = { set_state_category = metropolis }
 			}
 
 			custom_effect_tooltip = generic_skip_one_line_tt
@@ -1253,10 +1253,10 @@ focus_tree = {
 					}
 				}
 				51 = {
-					add_extra_state_shared_building_slots = 3
+					add_extra_state_shared_building_slots = 2
 					add_building_construction = {
 						type = industrial_complex
-						level = 3
+						level = 2
 						instant_build = yes
 					}
 				}
@@ -1308,18 +1308,6 @@ focus_tree = {
 		completion_reward = {
 			SWE = {
 				country_event = { id = wuw_GER_diplomacy.1 days = 2 }
-			}
-			66 = {
-				add_resource = {
-					type = tungsten
-					amount = 50
-				}
-			}
-			67 = {
-				add_resource = {
-					type = tungsten
-					amount = 50
-				}
 			}
 
 			custom_effect_tooltip = if_they_accept_tt
@@ -1862,10 +1850,10 @@ focus_tree = {
 						include_locked = yes
 					}
 				}
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
 					type = industrial_complex
-					level = 2
+					level = 1
 					instant_build = yes
 				}
 			}
@@ -2697,7 +2685,7 @@ focus_tree = {
 					}
 				}
 				random_select_amount = 2
-				add_extra_state_shared_building_slots = 2
+				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
 					type = arms_factory
 					level = 1


### PR DESCRIPTION
- Back to vanilla factory count
- Fixed a focus that was messing up due to different states
- Removed the 100 free tungsten they get from the Sweden focus
- Gives civ eco back to the left side industry tree